### PR TITLE
[PACKAGE] start entry removed for dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node app.js",
+    "dev": "node dev_server.js",
     "build": "cd pokemon-showdown && npm i && node build",
     "postbuild": "node dataToJson.js"
   },


### PR DESCRIPTION
### Ce qui a été fait

Dans le fichier `package.json`, l'entrée `start` a été retirée au profit de `dev` qui a pour fonctionnalité de lancer le mini-serveur `dev_server.js` pour des usages de développement.

### Motivation

Plutôt que de solliciter le directement le dépôt via `raw.githubusercontent.com/`, le développeur peut passer par ce mini-serveur, surtout si les fichiers JSON ne sont pas encore à jour sur le dépôt, ou que leurs structures sont différentes (notamment avec l'ajout des générations).

De plus, le provider sera intégré à la **stack docker** de coupcritique : si le développeur souhaite mettre à jour sa base de données dockerisée, il pourra invoquer le serveur du provider qui sera lancé dans cette stack.