### PR TITLE
Feature/add learnsets with gens

### DIFF
--- a/abilities.js
+++ b/abilities.js
@@ -4,9 +4,9 @@ const pokemonCollection = require('./pokemon');
 const { getGenAttributes, range, LAST_GEN } = require('./util');
 
 const abilitiesTextCollection = Object.entries(Abilities)
-	.filter(([key, value]) => !value.isNonstandard || value.isNonstandard === 'Past')
-	.reduce((accumulator,[key, value]) => ({...accumulator,[key]:{
-		name: value.name,
+	.filter(([key, { isNonstandard }]) => !isNonstandard || isNonstandard === 'Past')
+	.reduce((accumulator,[key, { name }]) => ({...accumulator,[key]:{
+		name,
 		description: AbilitiesText[key].desc || AbilitiesText[key].shortDesc,
 		shortDescription: AbilitiesText[key].shortDesc
 	}}),{});

--- a/abilities.js
+++ b/abilities.js
@@ -5,11 +5,14 @@ const { getGenAttributes, range, LAST_GEN } = require('./util');
 
 const abilitiesTextCollection = Object.entries(Abilities)
 	.filter(([key, { isNonstandard }]) => !isNonstandard || isNonstandard === 'Past')
-	.reduce((accumulator,[key, { name }]) => ({...accumulator,[key]:{
-		name,
-		description: AbilitiesText[key].desc || AbilitiesText[key].shortDesc,
-		shortDescription: AbilitiesText[key].shortDesc
-	}}),{});
+	.reduce((accumulator,[key, { name }]) => {
+				accumulator[key] = {
+				name,
+				description: AbilitiesText[key].desc || AbilitiesText[key].shortDesc,
+				shortDescription: AbilitiesText[key].shortDesc
+			}
+		return accumulator;
+	},{});
 
 // Method in order to create keys for abilitiesGen and to use them in abilities object
 const createKey = (name) => name.replace(/\W+/g,"").toLowerCase()

--- a/items.js
+++ b/items.js
@@ -4,13 +4,13 @@ const { LAST_GEN, range, getGenAttributes } = require('./util');
 
 const itemsCollection = Object.entries(Items)
 	.filter(
-		([key, value]) =>
-			(!value.isNonstandard ||
-			value.isNonstandard === 'Past' ||
-			value.isNonstandard === 'Unobtainable') && !key.match(/tr\d+/g) // pokemon shouldn't hold TRs --> we remove those items
+		([key, { isNonstandard }]) =>
+			(!isNonstandard ||
+			isNonstandard === 'Past' ||
+			isNonstandard === 'Unobtainable') && !key.match(/tr\d+/g) // pokemon shouldn't hold TRs --> we remove those items
 	)
-	.reduce((accumulator, [key, value]) => ({...accumulator, [key]:{
-		name: value.name,
+	.reduce((accumulator, [key, { name }]) => ({...accumulator, [key]:{
+		name,
 		description: ItemsText[key].desc
 	}}),{});
 

--- a/items.js
+++ b/items.js
@@ -9,10 +9,13 @@ const itemsCollection = Object.entries(Items)
 			isNonstandard === 'Past' ||
 			isNonstandard === 'Unobtainable') && !key.match(/tr\d+/g) // pokemon shouldn't hold TRs --> we remove those items
 	)
-	.reduce((accumulator, [key, { name }]) => ({...accumulator, [key]:{
-		name,
-		description: ItemsText[key].desc
-	}}),{});
+	.reduce((accumulator, [key, { name }]) => {
+		accumulator[key] = {
+			name,
+			description: ItemsText[key].desc
+		}
+		return accumulator;
+	},{});
 
 // Creating gen property in items
 Object.keys(itemsCollection).forEach((key) => {

--- a/learns.js
+++ b/learns.js
@@ -2,7 +2,8 @@ const { PokedexText } = require('./pokemon-showdown/.data-dist/text/pokedex');
 const { Learnsets } = require('./pokemon-showdown/.data-dist/learnsets');
 const { MovesText } = require('./pokemon-showdown/.data-dist/text/moves');
 const { FormatsData } = require('./pokemon-showdown/.data-dist/formats-data');
-const { pokemonIsStandard, range } = require('./util');
+const { pokemonIsStandard, range, getPokemonKeyFromName } = require('./util');
+const { Pokedex } = require('./pokemon-showdown/.data-dist/pokedex');
 const moves = require('./moves');
 
 const learns = [];
@@ -43,18 +44,65 @@ const availableGensByMove = moves.reduce((accumulator,object) => {
 	return accumulator
 },{})
 
-Object.entries(Learnsets)
-	.filter(([key, value]) => !FormatsData[key] || pokemonIsStandard(FormatsData[key]))
-	.forEach(([key, value]) => {
-		if (value.learnset) {
-			Object.keys(value.learnset).forEach(move => {
+Object.entries(Learnsets).forEach(([pokemonKey, { learnset }]) => {
+	if (FormatsData[pokemonKey] && !pokemonIsStandard(FormatsData[pokemonKey])) return;
+	const pokemon = Pokedex[pokemonKey];
+	// add baseForm learnset if form hasn't learnset
+	const baseFormKey = getPokemonKeyFromName(pokemon && pokemon.baseSpecies);
+	const baseForm = baseFormKey && Pokedex[baseFormKey];
+	if (!learnset) {
+		if (!baseFormKey) return null;
+		const baseFomLearns = Learnsets[baseFormKey];
+		if (!baseFomLearns || !baseFomLearns.learnset) return;
+		learnset = baseFomLearns.learnset;
+	}
+	// add prevo learnset
+	// prettier-ignore
+	const prevoKey = getPokemonKeyFromName(
+		(pokemon && pokemon.prevo) 
+		|| (baseForm && baseForm.prevo)
+	);
+	if (prevoKey) {
+		const prevoLearns = Learnsets[prevoKey];
+		if (prevoLearns && prevoLearns.learnset) {
+			learnset = { ...learnset, ...prevoLearns.learnset };
+		}
+		const prevo = Pokedex[prevoKey];
+		const prevoPrevoKey = getPokemonKeyFromName(prevo && prevo.prevo);
+		if (prevoPrevoKey) {
+			const prevoPrevoLearns = Learnsets[prevoPrevoKey];
+			if (prevoPrevoLearns && prevoPrevoLearns.learnset) {
+				learnset = { ...learnset, ...prevoPrevoLearns.learnset };
+			}
+		}
+	}
+	const pokemonName = PokedexText[pokemonKey] && PokedexText[pokemonKey].name;
+	Object.keys(learnset).forEach(move => {
+		learns.push({
+			pokemon: pokemonName || pokemonKey,
+			move: MovesText[move] ? MovesText[move].name : move,
+		});
+	});
+	// Add move to unreferenced formes
+	if (pokemon && pokemon.otherFormes) {
+		pokemon.otherFormes.forEach(formeName => {
+			const formeKey = getPokemonKeyFromName(formeName);
+			if (
+				!formeKey ||
+				Learnsets[formeKey] ||
+				(FormatsData[pokemonKey] && !pokemonIsStandard(FormatsData[pokemonKey]))
+			) {
+				return;
+			}
+			Object.keys(learnset).forEach(move => {
 				learns.push({
-					pokemon: PokedexText[key] ? PokedexText[key].name : key,
+					pokemon: formeName,
 					move: MovesText[move] ? MovesText[move].name : move,
-					gen: createGenArray(MovesText[move].name,value.learnset[move])
+					gen: createGenArray(MovesText[move].name,learnset[move])
 				});
 			});
-		}
-	});
+		});
+	}
+});
 
 module.exports = learns

--- a/learns.js
+++ b/learns.js
@@ -44,6 +44,11 @@ const availableGensByMove = moves.reduce((accumulator,object) => {
 	return accumulator
 },{})
 
+/**
+ * DONE: Associate gens by learn
+ * TODO: remove invalid gens for certain learns (Example : Mega-Charizard-X is from gen 6, but we have 3th gen for bite / "morsure" -> remove invalid gens) 
+ * Way: find minimum generation for pkmn, slice the createGenArray and take the second part (the first part has an invalid interval) 
+ */
 Object.entries(Learnsets).forEach(([pokemonKey, { learnset }]) => {
 	if (FormatsData[pokemonKey] && !pokemonIsStandard(FormatsData[pokemonKey])) return;
 	const pokemon = Pokedex[pokemonKey];
@@ -65,23 +70,26 @@ Object.entries(Learnsets).forEach(([pokemonKey, { learnset }]) => {
 	if (prevoKey) {
 		const prevoLearns = Learnsets[prevoKey];
 		if (prevoLearns && prevoLearns.learnset) {
-			learnset = { ...learnset, ...prevoLearns.learnset };
+			learnset = { ...prevoLearns, ...prevoLearns.learnset };
 		}
 		const prevo = Pokedex[prevoKey];
 		const prevoPrevoKey = getPokemonKeyFromName(prevo && prevo.prevo);
 		if (prevoPrevoKey) {
 			const prevoPrevoLearns = Learnsets[prevoPrevoKey];
 			if (prevoPrevoLearns && prevoPrevoLearns.learnset) {
-				learnset = { ...learnset, ...prevoPrevoLearns.learnset };
+				learnset = { ...prevoPrevoLearns, ...prevoPrevoLearns.learnset };
 			}
 		}
 	}
 	const pokemonName = PokedexText[pokemonKey] && PokedexText[pokemonKey].name;
 	Object.keys(learnset).forEach(move => {
-		learns.push({
-			pokemon: pokemonName || pokemonKey,
-			move: MovesText[move] ? MovesText[move].name : move,
-		});
+		if(MovesText[move]){
+			learns.push({
+				pokemon: pokemonName || pokemonKey,
+				move: MovesText[move] ? MovesText[move].name : move,
+				gen: createGenArray(MovesText[move].name,learnset[move])
+			});
+		}
 	});
 	// Add move to unreferenced formes
 	if (pokemon && pokemon.otherFormes) {
@@ -95,14 +103,15 @@ Object.entries(Learnsets).forEach(([pokemonKey, { learnset }]) => {
 				return;
 			}
 			Object.keys(learnset).forEach(move => {
-				learns.push({
-					pokemon: formeName,
-					move: MovesText[move] ? MovesText[move].name : move,
-					gen: createGenArray(MovesText[move].name,learnset[move])
-				});
+				if(MovesText[move]){
+					learns.push({
+						pokemon: formeName,
+						move: MovesText[move] ? MovesText[move].name : move,
+						gen: createGenArray(MovesText[move].name,learnset[move])
+					});
+				}
 			});
 		});
 	}
 });
-
 module.exports = learns

--- a/learns.js
+++ b/learns.js
@@ -5,6 +5,7 @@ const { FormatsData } = require('./pokemon-showdown/.data-dist/formats-data');
 const { pokemonIsStandard, range, getPokemonKeyFromName } = require('./util');
 const { Pokedex } = require('./pokemon-showdown/.data-dist/pokedex');
 const moves = require('./moves');
+const { gensByPokemon } = require('./pokemon');
 
 const learns = [];
 
@@ -97,6 +98,7 @@ Object.entries(Learnsets).forEach(([pokemonKey, { learnset }]) => {
 			const formeKey = getPokemonKeyFromName(formeName);
 			if (
 				!formeKey ||
+				!gensByPokemon[formeKey] ||
 				Learnsets[formeKey] ||
 				(FormatsData[pokemonKey] && !pokemonIsStandard(FormatsData[pokemonKey]))
 			) {
@@ -104,10 +106,15 @@ Object.entries(Learnsets).forEach(([pokemonKey, { learnset }]) => {
 			}
 			Object.keys(learnset).forEach(move => {
 				if(MovesText[move]){
+
+					let genLearns = createGenArray(MovesText[move].name,learnset[move])
+
+					genLearns = genLearns[0] < gensByPokemon[formeKey][0] ? genLearns.slice(genLearns.indexOf(gensByPokemon[formeKey][0])) : genLearns
+
 					learns.push({
 						pokemon: formeName,
 						move: MovesText[move] ? MovesText[move].name : move,
-						gen: createGenArray(MovesText[move].name,learnset[move])
+						gen: genLearns
 					});
 				}
 			});

--- a/moves.js
+++ b/moves.js
@@ -6,7 +6,8 @@ const createDiscriminate = ({ name, category, description, power, pp, accuracy, 
 
 const getGenAttributes = (object) => {
 	return Object.keys(object).filter((key) => key.includes('gen')).reduce((acc,index) => {
-		return { ...acc, [index]: index }
+		acc[index] = index;
+		return acc
 	},{})
 }
 
@@ -76,10 +77,13 @@ const lastGenMoves = Object.entries(Moves)
 	}}),{});
 
 const movesCollection = Object.entries(lastGenMoves)
-	.reduce((accumulator,[key, value]) => ({...accumulator, [createDiscriminate(value)]: {
-		...value,
-		gen: [ LAST_GEN ]
-	}}),{});
+	.reduce((accumulator,[key, value]) => {
+		accumulator[createDiscriminate(value)] = {
+			...value,
+			gen: [ LAST_GEN ]
+		}
+		return accumulator;
+	},{});
 
 
 const mods = (gen) => {

--- a/moves.js
+++ b/moves.js
@@ -63,7 +63,7 @@ const determineCategory = (gen, type, initialCategory) => {
 }
 
 const lastGenMoves = Object.entries(Moves)
-	.filter(([key, value]) => !value.isNonstandard || value.isNonstandard === 'Past')
+	.filter(([key, { isNonstandard } ]) => !isNonstandard || isNonstandard === 'Past')
 	.reduce((accumulator,[key, value]) => ({...accumulator, [key]: {
 		name: value.name,
 		category: value.category,

--- a/natures.js
+++ b/natures.js
@@ -1,9 +1,9 @@
 const { Natures } = require('./pokemon-showdown/.data-dist/natures');
 
-const natures = Object.values(Natures).map(value => {
-	const nature = { name: value.name };
-	if (value.plus) nature[value.plus] = 1;
-	if (value.minus) nature[value.minus] = -1;
+const natures = Object.values(Natures).map(({ name, plus, minus }) => {
+	const nature = { name };
+	if (plus) nature[plus] = 1;
+	if (minus) nature[minus] = -1;
 	return nature;
 });
 

--- a/pokemon.js
+++ b/pokemon.js
@@ -7,11 +7,13 @@ const createDiscriminant = ({name,baseStats,types,abilities}) => JSON.stringify(
 const pokemons = Object.entries(Pokedex)
 	.filter(([key, value]) => !FormatsData[key] || pokemonIsStandard(FormatsData[key]))
 	.reduce((accumulator, [key,value]) => {
-
-		return {...accumulator, [createDiscriminant(value)]:{
+		
+			accumulator[createDiscriminant(value)] = {
 			...value,
 			gen: [LAST_GEN]
-		}}
+			}
+
+		return accumulator;
 	},{});
 
 
@@ -28,7 +30,8 @@ const mods = (gen) => {
 		if(pokemonIsStandard(FormatsData[key]))
 		{
 			const FormatsDataPokemon = FormatsData[key]
-			return {...accumulator, [key] : FormatsDataPokemon}
+			accumulator[key] = FormatsDataPokemon;
+			return accumulator;
 		}
 		return accumulator
 

--- a/pokemon.js
+++ b/pokemon.js
@@ -1,17 +1,19 @@
 const { Pokedex } = require('./pokemon-showdown/.data-dist/pokedex');
 const { FormatsData } = require('./pokemon-showdown/.data-dist/formats-data');
 const { pokemonIsStandard, LAST_GEN } = require('./util');
-
+const gensByPokemon = {} // will be used for learns
 const createDiscriminant = ({name,baseStats,types,abilities}) => JSON.stringify({name,baseStats,types,abilities})
 
 const pokemons = Object.entries(Pokedex)
 	.filter(([key, value]) => !FormatsData[key] || pokemonIsStandard(FormatsData[key]))
 	.reduce((accumulator, [key,value]) => {
-		
-			accumulator[createDiscriminant(value)] = {
-			...value,
-			gen: [LAST_GEN]
-			}
+
+		gensByPokemon[key] = [LAST_GEN]
+
+		accumulator[createDiscriminant(value)] = {
+		...value,
+		gen: [LAST_GEN]
+		}
 
 		return accumulator;
 	},{});
@@ -144,12 +146,14 @@ for(let gen=LAST_GEN-1; gen > 0; gen--)
 					const richGenPokemonObject = cleanAbilities(gen,Object.assign(lastGenPokemon, inheritedPokemonInfo))
 					const discriminant = createDiscriminant(richGenPokemonObject)
 
-					if(pokemons.hasOwnProperty(discriminant))
+					if(pokemons.hasOwnProperty(discriminant)){
 						pokemons[discriminant]['gen'].push(gen)
-					else {
-							
+						gensByPokemon[key].push(gen);
+					} else {
 						pokemons[discriminant] = richGenPokemonObject
 						pokemons[discriminant]['gen'] = [gen]
+						if(gensByPokemon[key])
+							gensByPokemon[key].push(gen);
 					}
 
 				}
@@ -188,4 +192,6 @@ const resultPokemons = Object.values(pokemons).map((value) => {
 	
 })
 
+Object.values(gensByPokemon).forEach((value) => value.sort())
 module.exports = resultPokemons
+module.exports.gensByPokemon = gensByPokemon

--- a/types.js
+++ b/types.js
@@ -1,9 +1,9 @@
 const { TypeChart } = require('./pokemon-showdown/.data-dist/typechart');
 
 const WEAKNESS = { 0: 1, 1: 2, 2: 0.5, 3: 0 }; // translate weakness ratio
-const types = Object.entries(TypeChart).map(([key, value]) => ({
+const types = Object.entries(TypeChart).map(([key, { damageTaken }]) => ({
 	name: key,
-	weaknesses: Object.entries(value.damageTaken).map(([key, value]) => ({
+	weaknesses: Object.entries(damageTaken).map(([key, value]) => ({
 		name: key,
 		ratio: WEAKNESS[value],
 	})),

--- a/util.js
+++ b/util.js
@@ -42,7 +42,7 @@ const getPokemonKeyFromName = (pokemonName) => {
  * Hence, we have no choice to read and parse the learnsets file
  * 
  * The learnsets file tells what moves can be learned from all pokemon,
- * it can be either by leveling, evolution, transferring by generation... it is safe to assume
+ * it can either be by leveling, evolution, transferring by generation... it is safe to assume
  * that it gathers all the required data 
  * 
  * The result's structure is the following :

--- a/util.js
+++ b/util.js
@@ -20,14 +20,22 @@ const writeFile = (fileName, values) => fileSystem.writeFile(
 	e => log(fileName, e)
 );
 
-const pokemonIsStandard = value =>
-	!value.isNonstandard ||
-	value.isNonstandard === 'Past' || // keep pokemons that are not import in gen8
-	value.isNonstandard === 'Gigantamax' || // keep Gmax forms
-	value.isNonstandard === 'Unobtainable' &&  // keep Unobtainable real mons
-	value.tier !== 'Illegal'
+const pokemonIsStandard = ({ isNonstandard }) =>
+	!isNonstandard ||
+	isNonstandard === 'Past' || // keep pokemons that are not import in gen8
+	isNonstandard === 'Gigantamax' || // keep Gmax forms
+	isNonstandard === 'Unobtainable'  // keep Unobtainable real mons
 
 
+const { PokedexText } = require('./pokemon-showdown/.data-dist/text/pokedex');
+const pokedexEntries = Object.entries(PokedexText);
+// Applying GeoDaz's modifications from 0088816fc5ec17b71d085edf26fd7287d1b9b4b6
+const getPokemonKeyFromName = (pokemonName) => {
+	if (!pokemonName) return null;
+	let pokedexEntry = pokedexEntries.find(([key, { name }]) => name === pokemonName);
+	if (!pokedexEntry || !pokedexEntry.length) return null;
+	return pokedexEntry[0];
+};
 /**
  * There is no other way to find a move's gen (unlike for pokemon by reading 
  * the format-data file for each gen or for items by accessing the gen property in the items file)
@@ -94,5 +102,6 @@ module.exports = {
 	LAST_GEN,
 	movesByGen,
 	range,
-	getGenAttributes
+	getGenAttributes,
+	getPokemonKeyFromName
 }


### PR DESCRIPTION
## Ce qui a été fait

Modification des fichiers suivants :

- `pokemon.js` : construction d'un objet regroupant par pokémon / forme, leurs générations
- `learns.js` : Correction de la construction du tableau des générations pour les formes.

Le problème qui est apparu dans la construction de ce tableau, est que pour les formes spéciales (Mega, G-Max), qui héritent des moves des formes de base, héritent également des générations des moves.

Charizard-Mega hérite du move Aerial Ace, que possède Charizard à partir de la génération 3 :

```json
{"pokemon":"Charizard","move":"Aerial Ace","gen":[3,4,5,6,7,8]}
```
```json
{"pokemon":"Charizard-Mega-X","move":"Aerial Ace","gen"[3,4,5,6,7,8]}
```

Or ce n'est pas valide, étant donné que les Mega n'apparaissent qu'en 6ème génération.