### PR TITLE
[DATA] moves : add missing findInheritedMovesGenProperty calls

### DIFF
--- a/moves.js
+++ b/moves.js
@@ -110,8 +110,8 @@ for(let gen=LAST_GEN-1; gen > 0; gen--)
 							shortDescription:  Object.keys(multipleDescriptionGen).length > 0 && multipleDescriptionGen["gen"+gen] ? MovesText[key][multipleDescriptionGen["gen"+gen]].shortDesc : MovesText[key].shortDesc,
 							power: findInheritedMovesGenProperty(gen,key,"basePower"),
 							pp: findInheritedMovesGenProperty(gen,key,"pp"),
-							accuracy: lastGenMoves[key].accuracy,
-							type: lastGenMoves[key].type
+							accuracy: findInheritedMovesGenProperty(gen,key,"accuracy"),
+							type: findInheritedMovesGenProperty(gen,key,"type")
 						}
 
 						const newDiscriminate = createDiscriminate(moveGen)


### PR DESCRIPTION
## Problème constaté

Certains moves ne possèdent pas le même type d'une génération à une autre.
C'est le cas du move Charme : antérieurement à la 6ème génération, il possède le type **normal**, sinon il possède le type **fée**.

## Raison

On hérite pas la valeur antérieure pour le type de move pour les générations antérieures.

## Ce qui a été fait

Modification du fichier `moves.js`

- Ajout d'un appel à la fonction `findInheritedMovesGenProperty` pour la construction de chaque objet move, au niveau de la propriété `type`, mais aussi sur `accuracy` (sûrement inutile, car la statistique de la précision change très peu, mais autant rester prudent)