### PR TITLE
[DATA] Moves : manage accuracy for non-offensive moves

### DIFF
--- a/moves.js
+++ b/moves.js
@@ -22,12 +22,18 @@ const findInheritedMovesGenProperty = (gen,moveName,property) => {
 		if(nextMoveGen)
 		{
 			if(nextMoveGen[property]){
+				if(property === 'accuracy' && nextMoveGen[property] === true)
+					nextMoveGen[property] = null
 				return nextMoveGen[property];
 			}
 		}
 	}
 	if(property === "basePower")
 		property = "power"
+
+	if(property === 'accuracy' && nextMoveGen[property] === true)
+		nextMoveGen[property] = null
+	
 	return lastGenMoves[moveName][property]
 }
 


### PR DESCRIPTION
## Ce qui a été constaté

**Régression :** il a été décidé d'hériter la précision des moves pour les générations antérieures.
Or, pour certains moves, la précision est représentée par une valeur booléenne, ce qui n'est pas un type numérique (contrainte de la structure de la table moves dans la base de données)

## Ce qui a été fait

Modification du fichier `moves.js` :

- Au niveau de la fonction `findInheritedMovesGenProperty`, si on cherche à récupérer la valeur pour la propriété `accuracy`, et que cette dernière est de type booléen, on le transforme en `null`.