### PR TITLE
Feature/versions structure

### DIFF
--- a/abilities.js
+++ b/abilities.js
@@ -81,12 +81,11 @@ Object.entries(abilitiesTextCollection).forEach(([key,value]) => {
 	if(otherGens.length > 0)
 	{
 		otherGens.forEach((otherGen,index) => {
-		
 			abilities.push({
 				name: value.name,
 				description: AbilitiesText[key]["gen"+otherGen].desc || AbilitiesText[key]["gen"+otherGen].shortDesc,
 				shortDescription: AbilitiesText[key]["gen"+otherGen].shortDesc,
-				gen: index == 0 ? range(abilitiesGen[key][0],otherGen) : [otherGen]
+				gen: index == 0 && abilitiesGen[key] ? range(abilitiesGen[key][0],otherGen) : [otherGen]
 			})
 		})
 
@@ -115,4 +114,21 @@ Object.entries(abilitiesTextCollection).forEach(([key,value]) => {
 
 abilities[0]["gen"] = range(1,LAST_GEN)
 
-module.exports = abilities
+const intermediaryObject = abilities.reduce((accumulator,{name,description,shortDescription,gen}) => {
+
+	const key = JSON.stringify(name)
+
+	if(!accumulator.hasOwnProperty(key))
+		accumulator[key] = {
+			name,
+			versions: []	
+		}
+	
+	accumulator[key].versions.push({description,shortDescription,gen})
+
+
+	return accumulator;
+
+},{})
+
+module.exports = Object.values(intermediaryObject).map((value) => value)

--- a/abilities.js
+++ b/abilities.js
@@ -1,6 +1,6 @@
 const { Abilities } = require('./pokemon-showdown/.data-dist/abilities');
 const { AbilitiesText } = require('./pokemon-showdown/.data-dist/text/abilities');
-const pokemonCollection = require('./pokemon');
+const { pokemonCollection } = require('./pokemon');
 const { getGenAttributes, range, LAST_GEN } = require('./util');
 
 const abilitiesTextCollection = Object.entries(Abilities)
@@ -85,7 +85,7 @@ Object.entries(abilitiesTextCollection).forEach(([key,value]) => {
 				name: value.name,
 				description: AbilitiesText[key]["gen"+otherGen].desc || AbilitiesText[key]["gen"+otherGen].shortDesc,
 				shortDescription: AbilitiesText[key]["gen"+otherGen].shortDesc,
-				gen: index == 0 && abilitiesGen[key] ? range(abilitiesGen[key][0],otherGen) : [otherGen]
+				gen: index == 0 ? range(abilitiesGen[key][0],otherGen) : [otherGen]
 			})
 		})
 

--- a/abilities.js
+++ b/abilities.js
@@ -131,4 +131,4 @@ const intermediaryObject = abilities.reduce((accumulator,{name,description,short
 
 },{})
 
-module.exports = Object.values(intermediaryObject).map((value) => value)
+module.exports = Object.values(intermediaryObject)

--- a/dataToJson.js
+++ b/dataToJson.js
@@ -6,9 +6,9 @@ const { writeFile } = require('./util');
 const abilities = require('./abilities')
 const items = require('./items')
 const learns = require('./learns')
-const moves = require('./moves')
+const { moves } = require('./moves')
 const natures = require('./natures')
-const pokemons = require('./pokemon')
+const { pokemons } = require('./pokemon')
 const pokemonTier = require('./pokemonTier')
 const types = require('./types')
 

--- a/items.js
+++ b/items.js
@@ -50,5 +50,24 @@ Object.keys(itemsCollection).forEach((key) => {
 		itemsCollection[key]["gen"] = range(Items[key]["gen"],LAST_GEN)
 })
 
-const items = Object.values(itemsCollection)
+const intermediaryObject = Object.values(itemsCollection).reduce((accumulator,value) => {
+	
+	const { name, description, gen } = value
+
+	const key = JSON.stringify({ name })
+
+	if(!accumulator.hasOwnProperty(key)){
+		accumulator[key] = {
+			name,
+			versions: []
+		};
+	}
+	
+	accumulator[key].versions.push({description, gen})
+	
+	return accumulator
+},{})
+
+const items = Object.values(intermediaryObject).map((value) => value)
 module.exports = items
+

--- a/items.js
+++ b/items.js
@@ -68,6 +68,6 @@ const intermediaryObject = Object.values(itemsCollection).reduce((accumulator,va
 	return accumulator
 },{})
 
-const items = Object.values(intermediaryObject).map((value) => value)
+const items = Object.values(intermediaryObject)
 module.exports = items
 

--- a/learns.js
+++ b/learns.js
@@ -4,7 +4,7 @@ const { MovesText } = require('./pokemon-showdown/.data-dist/text/moves');
 const { FormatsData } = require('./pokemon-showdown/.data-dist/formats-data');
 const { pokemonIsStandard, range, getPokemonKeyFromName } = require('./util');
 const { Pokedex } = require('./pokemon-showdown/.data-dist/pokedex');
-const moves = require('./moves');
+const { movesCollection } = require('./moves');
 const { gensByPokemon } = require('./pokemon');
 
 const learns = [];
@@ -35,7 +35,7 @@ const createGenArray = (moveName,learnsetMoveData) => {
  * Return an object that shows for each move, the valid generations
  * Structure : { 'move name': [gens] }
  */
-const availableGensByMove = moves.reduce((accumulator,object) => {
+const availableGensByMove = movesCollection.reduce((accumulator,object) => {
 	if(!/Not available in gen \d/.test(object["description"])){
 		if(accumulator[object.name])
 			accumulator[object.name] = [...accumulator[object.name], ...object["gen"]].sort()

--- a/moves.js
+++ b/moves.js
@@ -3,8 +3,6 @@ const { MovesText } = require('./pokemon-showdown/.data-dist/text/moves');
 const { LAST_GEN, movesByGen } = require('./util');
 
 const createDiscriminate = ({ name, category, description, power, pp, accuracy, type }) => JSON.stringify({ name, category, description, power, pp, accuracy, type })
-const createDiscriminantVersion = ({ name }) => JSON.stringify({name});
-const versionObject = ({category, description, power, pp, accuracy, type}) => ({category, description, power, pp, accuracy, type})
 
 const getGenAttributes = (object) => {
 	return Object.keys(object).filter((key) => key.includes('gen')).reduce((acc,index) => {
@@ -140,22 +138,23 @@ Object.keys(movesCollection).forEach((key) => {
 	movesCollection[key]["gen"] = movesCollection[key]["gen"].sort()
 })
 
-const intermediaryObject = Object.values(movesCollection).reduce((accumulator,value) => {
+const intermediaryObject = Object.values(movesCollection).reduce((accumulator,{name,category, description, power, pp, accuracy, type}) => {
 
-	const key = createDiscriminantVersion(value);
+	const key = JSON.stringify(name);
 
 	if(!accumulator.hasOwnProperty(key)){
 		accumulator[key] = {
-			name: value.name,
+			name,
 			versions: []
 		};
 	}
 
-	accumulator[key].versions.push(versionObject(value))
+	accumulator[key].versions.push({category, description, power, pp, accuracy, type})
 	
 	return accumulator
 
 },{});
 
-module.exports = Object.values(intermediaryObject).map(value => value)
+module.exports.movesCollection = Object.values(movesCollection)
+module.exports.moves = Object.values(intermediaryObject).map(value => value)
 	

--- a/moves.js
+++ b/moves.js
@@ -3,6 +3,8 @@ const { MovesText } = require('./pokemon-showdown/.data-dist/text/moves');
 const { LAST_GEN, movesByGen } = require('./util');
 
 const createDiscriminate = ({ name, category, description, power, pp, accuracy, type }) => JSON.stringify({ name, category, description, power, pp, accuracy, type })
+const createDiscriminantVersion = ({ name }) => JSON.stringify({name});
+const versionObject = ({category, description, power, pp, accuracy, type}) => ({category, description, power, pp, accuracy, type})
 
 const getGenAttributes = (object) => {
 	return Object.keys(object).filter((key) => key.includes('gen')).reduce((acc,index) => {
@@ -138,4 +140,22 @@ Object.keys(movesCollection).forEach((key) => {
 	movesCollection[key]["gen"] = movesCollection[key]["gen"].sort()
 })
 
-module.exports = Object.values(movesCollection)
+const intermediaryObject = Object.values(movesCollection).reduce((accumulator,value) => {
+
+	const key = createDiscriminantVersion(value);
+
+	if(!accumulator.hasOwnProperty(key)){
+		accumulator[key] = {
+			name: value.name,
+			versions: []
+		};
+	}
+
+	accumulator[key].versions.push(versionObject(value))
+	
+	return accumulator
+
+},{});
+
+module.exports = Object.values(intermediaryObject).map(value => value)
+	

--- a/pokemon.js
+++ b/pokemon.js
@@ -244,5 +244,5 @@ module.exports.pokemonCollection = Object.values(pokemons).map((value) => {
 	
 })
 
-module.exports.pokemons = Object.values(intermediaryObject).map((value) => value)
+module.exports.pokemons = Object.values(intermediaryObject)
 module.exports.gensByPokemon = gensByPokemon

--- a/pokemon.js
+++ b/pokemon.js
@@ -135,7 +135,8 @@ for(let gen=LAST_GEN-1; gen > 0; gen--)
 					const lastGenPokemon = JSON.parse(JSON.stringify(modsByGen[LAST_GEN]['Pokedex'][key]))
 					
 					// Will check and fetch values of next gen (smogon system uses reverse inheritence, example : gen1 inherit values from gen2)
-					const inheritedPokemonInfo = { 
+					const inheritedPokemonInfo = {
+						num: findInheritedPokemonGenProperty(gen,key,'num'), 
 						baseStats: findInheritedPokemonGenProperty(gen,key,'baseStats'),
 						abilities: findInheritedPokemonGenProperty(gen,key,'abilities'),
 						types: findInheritedPokemonGenProperty(gen,key,'types')
@@ -164,6 +165,7 @@ for(let gen=LAST_GEN-1; gen > 0; gen--)
 
 const resultPokemons = Object.values(pokemons).map((value) => { 
 	const object = ({
+		num: value.num,
 		name: value.name,
 		type_1: value.types[0],
 		type_2: value.types.length > 1 ? value.types[1] : null,

--- a/pokemon.js
+++ b/pokemon.js
@@ -214,5 +214,35 @@ const intermediaryObject = Object.values(pokemons).reduce((accumulator,value) =>
 },{})
 
 Object.values(gensByPokemon).forEach((value) => value.sort())
-module.exports = Object.values(intermediaryObject).map((value) => value)
+module.exports.pokemonCollection = Object.values(pokemons).map((value) => { 
+	const object = ({
+		name: value.name,
+		type_1: value.types[0],
+		type_2: value.types.length > 1 ? value.types[1] : null,
+		hp: value.baseStats.hp,
+		atk: value.baseStats.atk,
+		def: value.baseStats.def,
+		spa: value.baseStats.spa,
+		spd: value.baseStats.spd,
+		spe: value.baseStats.spe,
+		weight: value.weightkg,
+		baseForm: value.baseSpecies ? value.baseSpecies : null,
+		prevo: value.prevo ? value.prevo : null,
+		gen: value.gen.sort()
+	})
+
+	if(value.abilities){
+		if(value.abilities['0'])
+			object["ability_1"] = value.abilities['0']
+		if(value.abilities['1'])
+			object["ability_2"] = value.abilities['1']
+		if(value.abilities['H'])
+			object["ability_hidden"] = value.abilities['H']
+	}
+
+	return object
+	
+})
+
+module.exports.pokemons = Object.values(intermediaryObject).map((value) => value)
 module.exports.gensByPokemon = gensByPokemon


### PR DESCRIPTION
## Contexte

Pour régler les soucis de correspondance entre les différentes générations, la structure de données de l'application coupcritique a changé.

On décide de répertorier, au sein d'une entité, **plusieurs versions qu'elle peut contenir**.