### PR TITLE
Feature/pokemon tier gen

### DIFF
--- a/pokemon.js
+++ b/pokemon.js
@@ -5,7 +5,7 @@ const gensByPokemon = {} // will be used for learns
 
 const createDiscriminant = ({name,baseStats,types,abilities}) => JSON.stringify({name,baseStats,types,abilities})
 const createDiscriminantVersion = ({name,baseForm,prevo}) => JSON.stringify({name,baseForm,prevo});
-const versionObject = ({type_1,type_2,hp,atk,def,spa,spd,spe,weight,gen}) => ({type_1,type_2,hp,atk,def,spa,spd,spe,weight,gen})
+const versionObject = ({type_1,type_2,hp,atk,def,spa,spd,spe,weight,gen, ability_1 = null, ability_2 = null, ability_hidden = null}) => ({type_1,type_2,hp,atk,def,spa,spd,spe,weight,gen,ability_1, ability_2, ability_hidden})
 
 const pokemons = Object.entries(Pokedex)
 	.filter(([key, value]) => !FormatsData[key] || pokemonIsStandard(FormatsData[key]))

--- a/pokemonTier.js
+++ b/pokemonTier.js
@@ -1,14 +1,32 @@
 const { FormatsData } = require('./pokemon-showdown/.data-dist/formats-data');
 const { PokedexText } = require('./pokemon-showdown/.data-dist/text/pokedex');
-const { pokemonIsStandard, removeParenthesis } = require('./util');
+const { pokemonIsStandard, removeParenthesis, LAST_GEN } = require('./util');
 
-const pokemonTier = Object.entries(FormatsData)
+let pokemonTier = Object.entries(FormatsData)
 	.filter(([key, value]) => pokemonIsStandard(value))
 	.map(([key, value]) => ({
 		pokemon: PokedexText[key] ? PokedexText[key].name : key,
 		tier: value.tier ? removeParenthesis(value.tier) : undefined,
 		technically: value.tier ? value.tier.startsWith('(') : false,
 		doublesTier: value.doublesTier ? removeParenthesis(value.doublesTier) : undefined,
+		gen: LAST_GEN
 	}));
+
+
+for(let gen=1; gen < LAST_GEN; gen++)
+{
+	const { FormatsData } = require(`./pokemon-showdown/.data-dist/mods/gen${gen}/formats-data`);
+	pokemonTier = pokemonTier.concat(Object.entries(FormatsData)
+	.filter(([key, value]) => pokemonIsStandard(value))
+	.map(([key, value]) => ({
+		pokemon: PokedexText[key] ? PokedexText[key].name : key,
+		tier: value.tier ? removeParenthesis(value.tier) : undefined,
+		technically: value.tier ? value.tier.startsWith('(') : false,
+		doublesTier: value.doublesTier ? removeParenthesis(value.doublesTier) : undefined,
+		gen
+	})));
+
+}
+
 
 module.exports = pokemonTier


### PR DESCRIPTION
## Ce qui a été fait

Modification des fichiers suivants : 

- `pokemons.js` : ajout des *talents dans la création des objets
- `pokemonTier.js` : ajout des générations (on ne stocke pas les générations dans un tableau, mais séparément)