### PR TITLE
[ACTIONS] JSON update : push json files after generation

### DIFF
--- a/.github/workflows/update-json.yaml
+++ b/.github/workflows/update-json.yaml
@@ -38,17 +38,26 @@ jobs: #this section contains the tasks / jobs that must be executed
           commit_author: GitHub Action <actions@github.com>
           skip_dirty_check: false
 
+      - name: "Push JSON to repository to trigger database update"
+        if: steps.auto-commit-action.outputs.changes_detected == 'true'
+        run: git push https://ii02735:${{ secrets.GITHUB_TOKEN }}@github.com/ii02735/dataprovider-pokemon-showdown.git main
+
       - name: Setup SSH connection
+        if: steps.auto-commit-action.outputs.changes_detected == 'true'
         run: >
           echo "${{ secrets.PRIVATE_KEY }}" > ./private_key && chmod 600 ./private_key &&
           echo '#!/bin/sh' >> ./passphrase_script.sh &&
           echo "echo ${{ secrets.PASSPHRASE }}" >> ./passphrase_script.sh &&
           chmod +x ./passphrase_script.sh
 
-      - run: ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-      - run: DISPLAY=1 SSH_ASKPASS="./passphrase_script.sh" ssh-add ./private_key < /dev/null
+      - if: steps.auto-commit-action.outputs.changes_detected == 'true'
+        run: ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+
+      - if: steps.auto-commit-action.outputs.changes_detected == 'true'
+        run: DISPLAY=1 SSH_ASKPASS="./passphrase_script.sh" ssh-add ./private_key < /dev/null
 
       - name: "Update remote"
+        if: steps.auto-commit-action.outputs.changes_detected == 'true'
         run: >
           ssh -p ${{ secrets.PORT }} ${{ secrets.USERNAME }}@${{ secrets.HOST }} -o StrictHostKeyChecking=no
           "cd ${{ secrets.REMOTE_PATH }}/ && 


### PR DESCRIPTION
## Contexte

Lorsque le workflow du fichier `update-json.yaml` régénère les fichiers JSON (smogon + usages), la mise à jour de la base de données ne s'exécute pas.

**Pour rappel :** la mise à jour de la base de données se fait en **2 temps :**

1. On régénère / met à jour les fichiers JSON depuis le workflow du fichier `update-json.yaml`
 
2. On exécute une **mise à jour de la base de données**, à condition qu'on observe des changements apportés suite à la mise à jour de ces fichiers. Il s'agit d'un second workflow, déclenché par le fichier `update-data.json`.

## Ce qui a été fait

Modification du fichier `update-json.yaml` : on indique qu'on doit **push les changements de la mise à jour des fichiers JSON** (s'il y en a), sur le dépôt, pour **déclencher** le second workflow mentionné ci-dessus.