### PR TITLE
Develop

### DIFF
--- a/.github/workflows/update-json-data.yaml
+++ b/.github/workflows/update-json-data.yaml
@@ -8,7 +8,7 @@ on: # This workflow must be triggered on two conditions
 env:
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
   POKEMON_SHOWDOWN_REPO: src/pokemon-showdown
-  USAGE_PATH: src/usages
+  USAGE_PATH: json/usages
 
 jobs: #this section contains the tasks / jobs that must be executed
   update_json_files: # the job name

--- a/src/providers/pokemon.js
+++ b/src/providers/pokemon.js
@@ -32,28 +32,34 @@ export default class PokemonProvider extends Provider {
     }
   }
 
+  fixAbilities(gen, rawObject) {
+    if (gen >= 3) {
+      for (const abilityClassifier of ["0", "1", "H", "S"]) {
+        if (rawObject.abilities[abilityClassifier]) {
+          const abilityFromShowdown = this.dex
+            .mod(`gen${gen}`)
+            .abilities.get(rawObject.abilities[abilityClassifier]);
+          rawObject[abilityClassifier] = abilityFromShowdown.exists
+            ? abilityFromShowdown.name
+            : null;
+        } else rawObject.abilities[abilityClassifier] = null;
+      }
+    }
+  }
+
   makeObject(rawObject, gen) {
     const [type_1, type_2] = rawObject.types;
-
     // Remove hidden ability before 5th gen
     if (gen < 5) rawObject.abilities["H"] = null;
     // Remove all abilities before 3th gen
-    else if (gen < 3) {
+    if (gen < 3) {
       rawObject.abilities["0"] = null;
       rawObject.abilities["1"] = null;
     }
 
     // Sometimes abilities are not put in the pokemon's data with the correct gen
-    for (const abilityClassifier of ["0", "1", "H", "S"]) {
-      if (rawObject.abilities[abilityClassifier]) {
-        const abilityFromShowdown = this.dex
-          .mod(`gen${gen}`)
-          .abilities.get(rawObject.abilities[abilityClassifier]);
-        rawObject[abilityClassifier] = abilityFromShowdown.exists
-          ? abilityFromShowdown.name
-          : null;
-      } else rawObject.abilities[abilityClassifier] = null;
-    }
+
+    this.fixAbilities(gen, rawObject);
 
     // Take in priority changesFrom (for not basic form)
     const baseForm =


### PR DESCRIPTION
## Ce qui a été fait

- Modification mineure de `src/providers/pokemon.js` concernant l'assignation des capacités spéciales en fonction des générations
- Modification mineure du fichier workflow `update-json-data.yaml`, la valeur renseignée pour `USAGE_PATH` concernant la génération des usages a été corrigée